### PR TITLE
Add support for base device object

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ from aiolookin import async_get_device
 
 
 async def main() -> None:
-    """Create the aiohttp session and run the example."""
     async with ClientSession() as session:
         device = await async_get_device("<IP ADDRESS>")
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,100 @@
 # 📶 aiolookin: an asyncio-based, Python3 library for LOOK.in devices
 
-<!-- [![CI](https://github.com/bachya/aiolookin/workflows/CI/badge.svg)](https://github.com/bachya/aiolookin/actions) -->
-<!-- [![PyPi](https://img.shields.io/pypi/v/aiolookin.svg)](https://pypi.python.org/pypi/aiolookin) -->
-<!-- [![Version](https://img.shields.io/pypi/pyversions/aiolookin.svg)](https://pypi.python.org/pypi/aiolookin) -->
-<!-- [![License](https://img.shields.io/pypi/l/aiolookin.svg)](https://github.com/bachya/aiolookin/blob/master/LICENSE) -->
-<!-- [![Code Coverage](https://codecov.io/gh/bachya/aiolookin/branch/master/graph/badge.svg)](https://codecov.io/gh/bachya/aiolookin) -->
-<!-- [![Maintainability](https://api.codeclimate.com/v1/badges/bd79edca07c8e4529cba/maintainability)](https://codeclimate.com/github/bachya/aiolookin/maintainability) -->
-<!-- [![Say Thanks](https://img.shields.io/badge/SayThanks-!-1EAEDB.svg)](https://saythanks.io/to/bachya) -->
+[![CI](https://github.com/bachya/aiolookin/workflows/CI/badge.svg)](https://github.com/bachya/aiolookin/actions)
+[![PyPi](https://img.shields.io/pypi/v/aiolookin.svg)](https://pypi.python.org/pypi/aiolookin)
+[![Version](https://img.shields.io/pypi/pyversions/aiolookin.svg)](https://pypi.python.org/pypi/aiolookin)
+[![License](https://img.shields.io/pypi/l/aiolookin.svg)](https://github.com/bachya/aiolookin/blob/master/LICENSE)
+[![Code Coverage](https://codecov.io/gh/bachya/aiolookin/branch/master/graph/badge.svg)](https://codecov.io/gh/bachya/aiolookin)
+[![Maintainability](https://api.codeclimate.com/v1/badges/a683f20d63d4735ceede/maintainability)](https://codeclimate.com/github/bachya/aiolookin/maintainability)
+[![Say Thanks](https://img.shields.io/badge/SayThanks-!-1EAEDB.svg)](https://saythanks.io/to/bachya)
 
 `aiolookin` is a Python 3, asyncio-friendly library for interacting with
 [LOOK.in](https://look-in.club/en) devices.
+
+# Python Versions
+
+`aiolookin` is currently supported on:
+
+* Python 3.6
+* Python 3.7
+* Python 3.8
+* Python 3.9
+
+# Installation
+
+```python
+pip install aiolookin
+```
+
+# Usage
+
+```python
+import asyncio
+
+from aiolookin import async_get_device
+
+
+async def main() -> None:
+    """Create the aiohttp session and run the example."""
+    device = await async_get_device("<IP ADDRESS>")
+
+
+asyncio.run(main())
+```
+
+By default, the library creates a new connection to Notion with each coroutine. If you
+are calling a large number of coroutines (or merely want to squeeze out every second of
+runtime savings possible), an
+[`aiohttp`](https://github.com/aio-libs/aiohttp) `ClientSession` can be used for connection
+pooling:
+
+```python
+import asyncio
+
+from aiohttp import ClientSession
+
+from aiolookin import async_get_device
+
+
+async def main() -> None:
+    """Create the aiohttp session and run the example."""
+    async with ClientSession() as session:
+        device = await async_get_device("<IP ADDRESS>")
+
+        # Get to work...
+
+
+asyncio.run(main())
+```
+
+## The `Device` Object
+
+Each `Device` object obtained by `async_get_device` has a series of useful properties:
+
+* `device_id`: the unique identifier of the device
+* `device_mode`: either `Executor` or `Sensor`
+* `eco_mode_enabled`: whether eco mode is enabled
+* `firmware`: the current firmware version
+* `homekit_enabled`: whether HomeKit is enabled
+* `internal_temp_c`: the device's internal temperature (in Celsius)
+* `mrdc`: the MRDC number (currently unknown what this does)
+* `name`: the name of the device
+* `power_mode`: the power mode of the device (A/C, battery)
+* `status`: the current status of the device
+* `type`: the type of device
+* `voltage`: the voltage being applied to the device (in millivolts)
+
+# Contributing
+
+1. [Check for open features/bugs](https://github.com/bachya/aiolookin/issues)
+  or [initiate a discussion on one](https://github.com/bachya/aiolookin/issues/new).
+2. [Fork the repository](https://github.com/bachya/aiolookin/fork).
+3. (_optional, but highly recommended_) Create a virtual environment: `python3 -m venv .venv`
+4. (_optional, but highly recommended_) Enter the virtual environment: `source ./venv/bin/activate`
+5. Install the dev environment: `script/setup`
+6. Code your new feature or bug fix.
+7. Write tests that cover your new functionality.
+8. Run tests and ensure 100% code coverage: `script/test`
+9. Update `README.md` with any new documentation.
+10. Add yourself to `AUTHORS.md`.
+11. Submit a pull request!

--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ async def main() -> None:
 asyncio.run(main())
 ```
 
-By default, the library creates a new connection to Notion with each coroutine. If you
-are calling a large number of coroutines (or merely want to squeeze out every second of
-runtime savings possible), an
+By default, the library creates a new connection to the device with each coroutine. If
+you are calling a large number of coroutines (or merely want to squeeze out every second
+of runtime savings possible), an
 [`aiohttp`](https://github.com/aio-libs/aiohttp) `ClientSession` can be used for connection
 pooling:
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@
 `aiolookin` is a Python 3, asyncio-friendly library for interacting with
 [LOOK.in](https://look-in.club/en) devices.
 
+- [Python Versions](#python-versions)
+- [Installation](#installation)
+- [Usage](#usage)
+- [Contributing](#contributing)
+
 # Python Versions
 
 `aiolookin` is currently supported on:

--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ from aiolookin import async_get_device
 
 
 async def main() -> None:
-    """Create the aiohttp session and run the example."""
     device = await async_get_device("<IP ADDRESS>")
 
 

--- a/aiolookin/__init__.py
+++ b/aiolookin/__init__.py
@@ -1,1 +1,2 @@
 """Define the aiolookin package."""
+from .device import async_get_device  # noqa

--- a/aiolookin/const.py
+++ b/aiolookin/const.py
@@ -1,0 +1,4 @@
+"""Define package constants."""
+import logging
+
+LOGGER = logging.getLogger(__package__)

--- a/aiolookin/device.py
+++ b/aiolookin/device.py
@@ -1,0 +1,146 @@
+"""Define anything needed to connect to a LOOK.in device."""
+import json
+from typing import Any, Dict, Optional
+
+from aiohttp import ClientSession, ClientTimeout
+from aiohttp.client_exceptions import ClientError
+
+from .const import LOGGER
+from .errors import RequestError
+
+DEFAULT_TIMEOUT = 10
+
+DEVICE_MODE_EXECUTOR = "Executor"
+DEVICE_MODE_SENSOR = "Sensor"
+DEVICE_MODE_UNKNOWN = "Unknown"
+
+DEVICE_MODE_MAP = {
+    "0": DEVICE_MODE_EXECUTOR,
+    "1": DEVICE_MODE_SENSOR,
+}
+
+
+class Device:
+    """Define the device."""
+
+    def __init__(
+        self, ip_address: str, *, session: Optional[ClientSession] = None
+    ) -> None:
+        """Initialize."""
+        self._device_info: Dict[str, str] = {}
+        self._ip_address = ip_address
+        self._session = session
+
+    def __repr__(self) -> str:
+        """Return a string representation of the device."""
+        return f"<Device type={self.type} id={self.device_id}>"
+
+    @property
+    def device_id(self) -> str:
+        """Return the device id."""
+        return self._device_info["ID"]
+
+    @property
+    def device_mode(self) -> str:
+        """Return the device mode."""
+        raw_mode = self._device_info["SensorMode"]
+        if raw_mode not in DEVICE_MODE_MAP:
+            LOGGER.debug("Unknown device mode value: %s", raw_mode)
+            return DEVICE_MODE_UNKNOWN
+        return DEVICE_MODE_MAP[raw_mode]
+
+    @property
+    def eco_mode_enabled(self) -> bool:
+        """Return whether the device has Eco mode enabled."""
+        return self._device_info["EcoMode"] == "on"
+
+    @property
+    def firmware(self) -> str:
+        """Return the device firmware."""
+        return self._device_info["Firmware"]
+
+    @property
+    def homekit_enabled(self) -> bool:
+        """Return whether the device is HomeKit-enabled."""
+        return bool(self._device_info["HomeKit"])
+
+    @property
+    def internal_temp_c(self) -> int:
+        """Return the device's internal temperature in C."""
+        return int(self._device_info["Temperature"])
+
+    @property
+    def mrdc(self) -> str:
+        """Return the MRDC (?)."""
+        return self._device_info["MRDC"]
+
+    @property
+    def name(self) -> str:
+        """Return the name."""
+        return self._device_info["Name"]
+
+    @property
+    def power_mode(self) -> str:
+        """Return the power mode."""
+        return self._device_info["PowerMode"]
+
+    @property
+    def status(self) -> str:
+        """Return the status."""
+        return self._device_info["Status"]
+
+    @property
+    def type(self) -> str:
+        """Return the device type."""
+        return self._device_info["Type"]
+
+    @property
+    def voltage(self) -> int:
+        """Return the current voltage in millivolts."""
+        return int(self._device_info["CurrentVoltage"])
+
+    async def _async_request(
+        self, method: str, endpoint: str, **kwargs: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Make an API request."""
+        url = f"http://{self._ip_address}/{endpoint}"
+        use_running_session = self._session and not self._session.closed
+
+        if use_running_session:
+            session = self._session
+        else:
+            session = ClientSession(timeout=ClientTimeout(total=DEFAULT_TIMEOUT))
+
+        assert session
+
+        data: Dict[str, Any] = {}
+
+        try:
+            async with session.request(method, url, **kwargs) as resp:
+                data = await resp.json()
+                resp.raise_for_status()
+        except (ClientError, json.decoder.JSONDecodeError) as err:
+            raise RequestError(f"Error while requesting {url}: {err}") from err
+        finally:
+            if not use_running_session:
+                await session.close()
+
+        LOGGER.debug("Received data for %s: %s", url, data)
+
+        return data
+
+    async def async_update_device_info(self) -> None:
+        """Get the latest device info.
+
+        Intended to be called right after instantiating the object.
+        """
+        self._device_info = await self._async_request("get", "device")
+
+
+async def async_get_device(
+    ip_address: str, *, session: Optional[ClientSession] = None
+) -> Device:
+    """Get a fully initialized device."""
+    device = Device(ip_address, session=session)
+    await device.async_update_device_info()
+    return device

--- a/aiolookin/errors.py
+++ b/aiolookin/errors.py
@@ -1,0 +1,13 @@
+"""Define package exceptions."""
+
+
+class LookInError(Exception):
+    """Define a base exception."""
+
+    pass
+
+
+class RequestError(LookInError):
+    """Define an error related a bad HTTP request."""
+
+    pass

--- a/examples/test_device_info.py
+++ b/examples/test_device_info.py
@@ -1,0 +1,35 @@
+"""Get a device and print its info."""
+import asyncio
+import logging
+
+from aiohttp import ClientSession
+
+from aiolookin import async_get_device
+from aiolookin.errors import LookInError
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def main() -> None:
+    """Create the aiohttp session and run the example."""
+    logging.basicConfig(level=logging.INFO)
+    async with ClientSession() as session:
+        try:
+            device = await async_get_device("172.16.20.236", session=session)
+            _LOGGER.info("Device ID: %s", device.device_id)
+            _LOGGER.info("Device Mode: %s", device.device_mode)
+            _LOGGER.info("Eco Mode Enabled: %s", device.eco_mode_enabled)
+            _LOGGER.info("Firmware: %s", device.firmware)
+            _LOGGER.info("HomeKit Enabled: %s", device.homekit_enabled)
+            _LOGGER.info("Internal Temperature (C): %s", device.internal_temp_c)
+            _LOGGER.info("MRDC: %s", device.mrdc)
+            _LOGGER.info("Name: %s", device.name)
+            _LOGGER.info("Power Mode: %s", device.power_mode)
+            _LOGGER.info("Status: %s", device.status)
+            _LOGGER.info("Type: %s", device.type)
+            _LOGGER.info("Voltage: %s", device.voltage)
+        except LookInError as err:
+            _LOGGER.error("There was an error: %s", err)
+
+
+asyncio.run(main())

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,0 +1,11 @@
+"""Define common test utilities."""
+import os
+
+TEST_IP_ADDRESS = "192.168.1.101"
+
+
+def load_fixture(filename):
+    """Load a fixture."""
+    path = os.path.join(os.path.dirname(__file__), "fixtures", filename)
+    with open(path, encoding="utf-8") as fptr:
+        return fptr.read()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+"""Define dynamic fixtures."""
+import json
+
+import pytest
+
+from .common import load_fixture
+
+
+@pytest.fixture(name="device_info", scope="session")
+def device_info_fixture():
+    """Load the controller state fixture data."""
+    return json.loads(load_fixture("device_info.json"))

--- a/tests/fixtures/device_info.json
+++ b/tests/fixtures/device_info.json
@@ -1,0 +1,16 @@
+{
+  "Type": "Remote",
+  "MRDC": "1234567890ABCDEF",
+  "Status": "Running",
+  "ID": "ABCD1234",
+  "Name": "Test Device",
+  "Time": "1629114787",
+  "Timezone": "-7",
+  "PowerMode": "5v",
+  "CurrentVoltage": "5889",
+  "Firmware": "2.36",
+  "Temperature": "53",
+  "HomeKit": "1",
+  "EcoMode": "on",
+  "SensorMode": "0"
+}

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1,0 +1,132 @@
+"""Define tests for the device."""
+import json
+import logging
+
+import aiohttp
+import pytest
+
+from aiolookin import async_get_device
+from aiolookin.errors import RequestError
+
+from .common import TEST_IP_ADDRESS
+
+
+@pytest.mark.asyncio
+async def test_api_error(aresponses):
+    """Test the API returning a non-2xx HTTP code."""
+    aresponses.add(
+        TEST_IP_ADDRESS,
+        "/device",
+        "get",
+        aresponses.Response(
+            text="Bad Request",
+            status=400,
+            headers={"Content-Type": "application/json; charset=utf-8"},
+        ),
+    )
+
+    async with aiohttp.ClientSession() as session:
+        with pytest.raises(RequestError):
+            await async_get_device(TEST_IP_ADDRESS, session=session)
+
+
+@pytest.mark.asyncio
+async def test_device_properties(aresponses, device_info):
+    """Test getting device properties."""
+    aresponses.add(
+        TEST_IP_ADDRESS,
+        "/device",
+        "get",
+        aresponses.Response(
+            text=json.dumps(device_info),
+            status=200,
+            headers={"Content-Type": "application/json; charset=utf-8"},
+        ),
+    )
+
+    async with aiohttp.ClientSession() as session:
+        device = await async_get_device(TEST_IP_ADDRESS, session=session)
+        assert device.device_id == "ABCD1234"
+        assert device.device_mode == "Executor"
+        assert device.eco_mode_enabled is True
+        assert device.firmware == "2.36"
+        assert device.homekit_enabled is True
+        assert device.internal_temp_c == 53
+        assert device.mrdc == "1234567890ABCDEF"
+        assert device.name == "Test Device"
+        assert device.power_mode == "5v"
+        assert device.status == "Running"
+        assert device.type == "Remote"
+        assert device.voltage == 5889
+
+
+@pytest.mark.asyncio
+async def test_device_properties_new_session(aresponses, device_info):
+    """Test getting device properties without an explicit ClientSession."""
+    aresponses.add(
+        TEST_IP_ADDRESS,
+        "/device",
+        "get",
+        aresponses.Response(
+            text=json.dumps(device_info),
+            status=200,
+            headers={"Content-Type": "application/json; charset=utf-8"},
+        ),
+    )
+
+    device = await async_get_device(TEST_IP_ADDRESS)
+    assert device.device_id == "ABCD1234"
+    assert device.device_mode == "Executor"
+    assert device.eco_mode_enabled is True
+    assert device.firmware == "2.36"
+    assert device.homekit_enabled is True
+    assert device.internal_temp_c == 53
+    assert device.mrdc == "1234567890ABCDEF"
+    assert device.name == "Test Device"
+    assert device.power_mode == "5v"
+    assert device.status == "Running"
+    assert device.type == "Remote"
+    assert device.voltage == 5889
+
+
+@pytest.mark.asyncio
+async def test_device_representation(aresponses, device_info):
+    """Test that a device is represented as a string correctly."""
+    aresponses.add(
+        TEST_IP_ADDRESS,
+        "/device",
+        "get",
+        aresponses.Response(
+            text=json.dumps(device_info),
+            status=200,
+            headers={"Content-Type": "application/json; charset=utf-8"},
+        ),
+    )
+
+    async with aiohttp.ClientSession() as session:
+        device = await async_get_device(TEST_IP_ADDRESS, session=session)
+        assert str(device) == "<Device type=Remote id=ABCD1234>"
+
+
+@pytest.mark.asyncio
+async def test_unknown_device_mode(aresponses, caplog, device_info):
+    """Test that an unknown device mode is captured correctly."""
+    caplog.set_level(logging.DEBUG)
+
+    device_info["SensorMode"] = "2"
+
+    aresponses.add(
+        TEST_IP_ADDRESS,
+        "/device",
+        "get",
+        aresponses.Response(
+            text=json.dumps(device_info),
+            status=200,
+            headers={"Content-Type": "application/json; charset=utf-8"},
+        ),
+    )
+
+    async with aiohttp.ClientSession() as session:
+        device = await async_get_device(TEST_IP_ADDRESS, session=session)
+        assert device.device_mode == "Unknown"
+        assert any("Unknown device mode" in e.message for e in caplog.records)


### PR DESCRIPTION
**Describe what the PR does:**

This PR adds support for a `Device` object, which currently relates to a [LOOK.in Remote 2](https://look-in.club/en/store). It's not _completely_ clear how future devices will be represented in this library, meaning that some sort of refactor may have to take place down the road.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [x] Add yourself to `AUTHORS.md`.
