### PR TITLE
Added fixture to simulate a "device server"

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,24 @@ import json
 
 import pytest
 
-from .common import load_fixture
+from .common import TEST_IP_ADDRESS, load_fixture
+
+
+@pytest.fixture(name="device_server")
+def device_server_fixture(aresponses, device_info):
+    """Define a fixture to an aresponses server that represents a device."""
+    aresponses.add(
+        TEST_IP_ADDRESS,
+        "/device",
+        "get",
+        aresponses.Response(
+            text=json.dumps(device_info),
+            status=200,
+            headers={"Content-Type": "application/json; charset=utf-8"},
+        ),
+    )
+
+    return aresponses
 
 
 @pytest.fixture(name="device_info", scope="session")

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -11,19 +11,9 @@ from .common import TEST_IP_ADDRESS
 
 
 @pytest.mark.asyncio
-async def test_invalid_sensor_type(aresponses, device_info, sensor_list):
+async def test_invalid_sensor_type(aresponses, device_server, sensor_list):
     """Test that requesting an unsupported sensor type throws the proper exception."""
-    aresponses.add(
-        TEST_IP_ADDRESS,
-        "/device",
-        "get",
-        aresponses.Response(
-            text=json.dumps(device_info),
-            status=200,
-            headers={"Content-Type": "application/json; charset=utf-8"},
-        ),
-    )
-    aresponses.add(
+    device_server.add(
         TEST_IP_ADDRESS,
         "/sensors",
         "get",
@@ -44,20 +34,10 @@ async def test_invalid_sensor_type(aresponses, device_info, sensor_list):
 
 @pytest.mark.asyncio
 async def test_sensor_values(
-    aresponses, device_info, ir_sensor_value, meteo_sensor_value, sensor_list
+    aresponses, device_server, ir_sensor_value, meteo_sensor_value, sensor_list
 ):
     """Test getting the latest value of a device's sensors."""
-    aresponses.add(
-        TEST_IP_ADDRESS,
-        "/device",
-        "get",
-        aresponses.Response(
-            text=json.dumps(device_info),
-            status=200,
-            headers={"Content-Type": "application/json; charset=utf-8"},
-        ),
-    )
-    aresponses.add(
+    device_server.add(
         TEST_IP_ADDRESS,
         "/sensors",
         "get",
@@ -67,7 +47,7 @@ async def test_sensor_values(
             headers={"Content-Type": "application/json; charset=utf-8"},
         ),
     )
-    aresponses.add(
+    device_server.add(
         TEST_IP_ADDRESS,
         "/sensors/IR",
         "get",
@@ -77,7 +57,7 @@ async def test_sensor_values(
             headers={"Content-Type": "application/json; charset=utf-8"},
         ),
     )
-    aresponses.add(
+    device_server.add(
         TEST_IP_ADDRESS,
         "/sensors",
         "get",
@@ -87,7 +67,7 @@ async def test_sensor_values(
             headers={"Content-Type": "application/json; charset=utf-8"},
         ),
     )
-    aresponses.add(
+    device_server.add(
         TEST_IP_ADDRESS,
         "/sensors/Meteo",
         "get",
@@ -109,19 +89,9 @@ async def test_sensor_values(
 
 
 @pytest.mark.asyncio
-async def test_sensor_list(aresponses, device_info, sensor_list):
+async def test_sensor_list(aresponses, device_server, sensor_list):
     """Test getting the list of sensors supported by the device."""
-    aresponses.add(
-        TEST_IP_ADDRESS,
-        "/device",
-        "get",
-        aresponses.Response(
-            text=json.dumps(device_info),
-            status=200,
-            headers={"Content-Type": "application/json; charset=utf-8"},
-        ),
-    )
-    aresponses.add(
+    device_server.add(
         TEST_IP_ADDRESS,
         "/sensors",
         "get",


### PR DESCRIPTION
**Describe what the PR does:**

This PR introduces a "device server" fixture, which is just an `aresponses` mocked server that tests can latch onto.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
