### PR TITLE
Alter class name standard for API endpoints

### DIFF
--- a/aiolookin/command.py
+++ b/aiolookin/command.py
@@ -4,7 +4,7 @@ from typing import Any, Awaitable, Callable, Dict, List, Optional, cast
 from .errors import CommandError
 
 
-class Command:
+class CommandAPI:
     """Define a command data object."""
 
     def __init__(self, async_request: Callable[..., Awaitable]) -> None:

--- a/aiolookin/device.py
+++ b/aiolookin/device.py
@@ -5,10 +5,10 @@ from typing import Any, Dict, List, Optional, Union, cast
 from aiohttp import ClientSession, ClientTimeout
 from aiohttp.client_exceptions import ClientError
 
-from .command import Command
+from .command import CommandAPI
 from .const import LOGGER
 from .errors import RequestError
-from .sensor import Sensor
+from .sensor import SensorAPI
 
 DEFAULT_TIMEOUT = 10
 
@@ -33,8 +33,8 @@ class Device:
         self._ip_address = ip_address
         self._session = session
 
-        self.command = Command(self._async_request)
-        self.sensor = Sensor(self._async_request)
+        self.command = CommandAPI(self._async_request)
+        self.sensor = SensorAPI(self._async_request)
 
     def __repr__(self) -> str:
         """Return a string representation of the device."""

--- a/aiolookin/sensor.py
+++ b/aiolookin/sensor.py
@@ -4,7 +4,7 @@ from typing import Any, Awaitable, Callable, Dict, List, cast
 from .errors import SensorError
 
 
-class Sensor:
+class SensorAPI:
     """Define a sensor data object."""
 
     def __init__(self, async_request: Callable[..., Awaitable]) -> None:


### PR DESCRIPTION
**Describe what the PR does:**

This PR modifies the existing standard for class names of classes that manage API endpoints. Doing this because I anticipate needing the existing standard elsewhere shortly...

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
